### PR TITLE
ci: skip SSH setup for PR branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
           persist-credentials: false
           submodules: true
       - name: Setup SSH
+        if: contains(github.ref, 'main')
         uses: MrSquaare/ssh-setup-action@84a60849dca0e42e04b9b73f930036654e4672ab
         with:
           host: github.com


### PR DESCRIPTION
Dependabot PRs fail because `MrSquaare/ssh-setup-action` requires `secrets.SSH_PRIVATE_KEY`, which is not available to Dependabot PRs. The SSH key is only needed for the push step (which only runs on `main`), so guard the SSH setup step with `if: contains(github.ref, 'main')`.

This unblocks CI on #155, #156, #157, #160, #161, #162.